### PR TITLE
Improve HTTPS Redirect Mechanism

### DIFF
--- a/https_check.inc.php
+++ b/https_check.inc.php
@@ -16,6 +16,7 @@ if($_SERVER['HTTPS'] != "on"){
 } else {
   /* Only use HTTPS for the next year */
   header("Strict-Transport-Security: max-age=31536000");
+  header("Content-Security-Policy: upgrade-insecure-requests;");
 }
 
 ?>

--- a/https_check.inc.php
+++ b/https_check.inc.php
@@ -1,6 +1,7 @@
 <?php
 
-if($_SERVER['HTTPS'] != "on"){ // if there was no secure connection, redirect to https version
+/* Redirect to HTTPS and refuse to serve HTTP */
+if($_SERVER['HTTPS'] != "on"){
   $_SERVER['FULL_URL'] = 'https://';
   if($_SERVER['SERVER_PORT']!='80')
     $_SERVER['FULL_URL'] .=  $_SERVER['HTTP_HOST'].':'.$_SERVER['SERVER_PORT'].$_SERVER['SCRIPT_NAME'];
@@ -10,16 +11,11 @@ if($_SERVER['HTTPS'] != "on"){ // if there was no secure connection, redirect to
     $_SERVER['FULL_URL'] .=  '?'.$_SERVER['QUERY_STRING'];
   }
 
-  //echo $_SERVER['FULL_URL'];
-
-  $delay = "3"; // 3 second delay
-  echo "For security reasons encryption needs to be enabled! Make sure to accept any security alerts.<br>";
-  echo "You will be redirected in ".$delay." seconds. Please wait...<br><br>";
-  echo "If redirection does not work please click <a href=".$_SERVER['FULL_URL'].">here</a>.";
-
-  echo '<meta http-equiv="refresh" content="'.$delay.';url='.$_SERVER['FULL_URL'].'">';
-
+  header("Location: " . $_SERVER['FULL_URL']);
   exit();
+} else {
+  /* Only use HTTPS for the next year */
+  header("Strict-Transport-Security: max-age=31536000");
 }
 
 ?>

--- a/https_check.inc.php
+++ b/https_check.inc.php
@@ -11,7 +11,7 @@ if($_SERVER['HTTPS'] != "on"){
     $_SERVER['FULL_URL'] .=  '?'.$_SERVER['QUERY_STRING'];
   }
 
-  header("Location: " . $_SERVER['FULL_URL']);
+  header("Location: " . $_SERVER['FULL_URL'], true, 301);
   exit();
 } else {
   /* Only use HTTPS for the next year */


### PR DESCRIPTION
This Pull Request improves the mechanism used to redirect to HTTPS in the following ways:

* It uses HTTP headers to redirect instead of HTML as it is a better and more reliable mechanism
* Makes the redirect a Permanent one, so browsers will remember this decision in the future
* Sends a `Strict-Transport-Security` header to the browser to instruct it to not visit this website again using HTTP for one year
* Uses a `Content-Security-Policy` header to upgrade all future insecure requests to HTTPS in the browser