### PR TITLE
Move admins to PHP array, from file

### DIFF
--- a/admins
+++ b/admins
@@ -1,2 +1,0 @@
-admin1@dep.uni.edu
-admin2@dep.uni.edu

--- a/conf.php
+++ b/conf.php
@@ -13,14 +13,13 @@
   /* The LDAP base DN */
   $ldap_bdn    = "dc=uoc,dc=gr";
 
-  /* The admins_file specified below contains the logins of the instructors
-   * and the teaching assistants. (syntax: one login per line)
-   * You can either create a new file (e.g. admins.txt) containing the desired
-   * logins or you can have this file point to the course's .rhosts file.
-   * (e.g. $admins_file = "home/lessons/hy120/.rhosts";)
-   */
-  //$admins_file = "../../.rhosts";
-  $admins_file = "./admins";
+  /* The admins array specified below contains the logins of the instructors
+   * and the teaching assistants. They will be able to add new exams, slots,
+   * as well as view and delete any and all data. */
+  $admins = array(
+    "admin1@dep.uni.edu",
+    "admin2@dep.uni.edu",
+  );
 
   /* This string will appear on the top of the webpage right next to the main
    * title "Rendezvous".

--- a/index.php
+++ b/index.php
@@ -219,19 +219,8 @@ if(check_db())
         }
         if($acc_type == 'admin')        // admin verification
         {
-          $adminFileRead = file_get_contents($admins_file);
-          $adminDatabase = explode("\n", $adminFileRead);
-            
-          if ( !$adminFileRead ){
-            echo 'Could not open the file "'.$admins_file.'" that lists the administrators!<br>';
-            echo 'Please specify a valid file in the <code>'.realpath('.').'/conf.php</code> file.<br>';
-            echo 'Make sure that this file is readable and has the appropriate permissions.';
-            exit;
-          }
-
-          foreach($adminDatabase as $admin){
-            //echo $admin . " <--> " . $login . "<br/>";
-            if($admin == $login){
+          foreach($admins as $admin){
+            if($admin === $login){
               $verified = true;
               break;
             }
@@ -239,8 +228,8 @@ if(check_db())
 
           if (!$verified) // You were not found in the administrators list
           {
-            echo 'Your login "'.$login.'" was not found in the list of administrators ("'.$admins_file.'")!<br>';
-            echo 'Please check the admins_file specified by the "conf.php" file ("'.realpath('.').'/conf.php").';
+            echo 'Your login ('.$login.') was not found in the list of administrators!<br>';
+            echo 'Please check the list of admins specified in the "conf.php" file ('.realpath('.').'/conf.php).';
             exit;
           }
 


### PR DESCRIPTION
This PR moves the list of administrators to a PHP array inside `conf.php` instead of the `admins` file. This provides a few benefits:

* The general public cannot get a list of the administrators by fetching the `admins` file.
* We avoid reading a file for every login request, and all the problems that may be associated with doing it (error handling, etc.)
* We avoid encoding problems (CRLF vs LF, etc.) on the input data

I believe that the reason this was a separate file was so that the `.rhosts` file could be used instead, that should already include a list of all admins. However, ever since the change and move to LDAP and the use of e-mail, this file should no longer be usable, and a separate `admins` file would probably have to be created every time. That said, we can probably drop the support for TXT files now, and use a better way.